### PR TITLE
zynqlinux/copy_to_sd_card.sh: Fail with error message if SD card not mounted

### DIFF
--- a/linux/zynqlinux/copy_to_sd_card.sh
+++ b/linux/zynqlinux/copy_to_sd_card.sh
@@ -16,10 +16,7 @@ if [ "$not_mounted" -eq "1" ]; then
 fi
 
 # Copy to SD card
-cp BOOT.bin          ${SD_BOOT_PARTITION}/.
-cp devicetree.dtb    ${SD_BOOT_PARTITION}/.
-cp uImage            ${SD_BOOT_PARTITION}/.
-cp uramdisk.image.gz ${SD_BOOT_PARTITION}/.
+cp BOOT.bin devicetree.dtb uImage uramdisk.image.gz ${SD_BOOT_PARTITION}/.
 
 # Unmount SD card
 sync

--- a/linux/zynqlinux/copy_to_sd_card.sh
+++ b/linux/zynqlinux/copy_to_sd_card.sh
@@ -6,6 +6,15 @@ if [[ -z "${SD_BOOT_PARTITION}" ]]; then
   SD_BOOT_PARTITION="/run/media/${USER}/ZYNQ_BOOT"
 fi
 
+# Check if boot partition of the SD card is mounted.
+grep -qs "$SD_BOOT_PARTITION " /proc/mounts
+not_mounted=$?
+if [ "$not_mounted" -eq "1" ]; then
+  echo "Error: Boot partition of SD card is not mounted at '${SD_BOOT_PARTITION}!"
+  echo "Please make sure it is mounted and adjust 'SD_BOOT_PARTITION' to its mount point."
+  exit 1
+fi
+
 # Copy to SD card
 cp BOOT.bin          ${SD_BOOT_PARTITION}/.
 cp devicetree.dtb    ${SD_BOOT_PARTITION}/.


### PR DESCRIPTION
Not urgent but good to have in next patch release IMO.